### PR TITLE
Correct critical typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ import { vueGsheets } from 'vue-gsheets'
 
 export default {
   mixins: [vueGsheets],
-  date: () => ({
+  data: () => ({
     COLUMNS: 3,
     sheetPageNumber: 1,
     SHEETID: '1Yc2esnockqfrNweacmegXnavuPly8PvjaRzqlRzaXTE'


### PR DESCRIPTION
In the documentation README, `data` is misspelled as `date` – this causes it to only import the predefined values from the package.